### PR TITLE
Update README to give guidance in the event of Node path problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ rvm use 2.0.0@generator-playbook --create --ruby-version
 yo playbook
 ````
 
+Should you run into an error such as `command yo not found` it is most
+likely a path issue cause by a Homebrew install of Node. Please refer
+to the top answer on this [stack overflow question](http://stackoverflow.com/questions/15846076/command-not-found-after-installation).
+
 ### View the Site Locally
 ````bash
 grunt server


### PR DESCRIPTION
@dcalhoun, as I was trying out generator-playbook, I kept getting `command yo not found` and had to check with the goons for the answer. If you have installed Node via Homebrew, you must correct $PATH.

The README now contains a sentence to help someone else in this predicament.

:sake: 
