### PR TITLE
Add grunt-replace for GitHub project pages support.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -135,9 +135,24 @@ PlaybookGenerator.prototype.askForDeployment = function askForDeployment() {
       }
     },
     {
+      name: 'ghPagesProject',
+      type: 'list',
+      message: 'GitHub Project or User/Organization site?',
+      choices: ['Project', 'User/Organization'],
+      when: function(answers) {
+        return answers.deployHost == 'GitHub Pages';
+      }
+    },
+    {
       name: 'deployBranch',
       message: 'Branch to deploy to',
-      default: 'gh-pages',
+      default: function(answers) {
+        if (answers.ghPagesProject === 'Project') {
+          return 'gh-pages';
+        } else {
+          return 'master';
+        };
+      },
       when: function (answers) {
         return answers.deploy;
       }
@@ -148,13 +163,16 @@ PlaybookGenerator.prototype.askForDeployment = function askForDeployment() {
 
   this.prompt(prompts, function (props) {
 
-    this.deploy       = props.deploy;
-    this.deployBranch = props.deployBranch;
+    this.deploy         = props.deploy;
+    this.deployBranch   = props.deployBranch;
+    this.ghOwner        = props.ghOwner;
+    this.ghRepo         = props.ghRepo;
+    this.ghPagesProject = props.ghPagesProject.replace('/', '_').toLowerCase();
 
     if (this.deployHost == 'Heroku') {
       this.deployRemote = 'git@heroku.com:' + props.herokuRepo + '.git';
     } else {
-      this.deployRemote = 'git@github.com:' + props.ghOwner + '/' + props.ghRepo + '.git';
+      this.deployRemote = 'git@github.com:' + this.ghOwner + '/' + this.ghRepo + '.git';
     }
 
     cb();

--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -299,6 +299,24 @@ module.exports = function (grunt) {
           branch: '<%= deployBranch %>'
         }
       }
+    },<% } %><% if (ghPagesProject === 'project') { %>
+    replace: {
+      dist: {
+        options: {
+          patterns: [
+            {
+              match: /("?)\/?assets\//g,
+              replacement: '$1http://<%= ghOwner %>.github.io/<%= ghRepo %>/assets/'
+            }
+          ]
+        },
+        files: [
+          {
+            expand: true,
+            src: ['dist/**/*.html']
+          }
+        ]
+      }
     },<% } %>
     jshint: {
       options: {
@@ -395,9 +413,8 @@ module.exports = function (grunt) {
   ]);<% if (deploy) { %>
 
   grunt.registerTask('deploy', [
-    'check',
-    'test',
-    'build',
+    'default',<% if (ghPagesProject === 'project') { %>
+    'replace',<% } %>
     'buildcontrol'
   ]);<% } %>
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -18,7 +18,8 @@
     "grunt-contrib-watch": "~0.5.2",
     "grunt-concurrent": "~0.3.0",
     "grunt-csscss": "~0.5.0",
-    "grunt-jekyll": "git://github.com/dannygarcia/grunt-jekyll.git#aa03074ee0f5b69dc9d7a0e6ced6bb8cd923add6",
+    "grunt-jekyll": "git://github.com/dannygarcia/grunt-jekyll.git#aa03074ee0f5b69dc9d7a0e6ced6bb8cd923add6",<% if (ghPagesProject === 'project') { %>
+    "grunt-replace": "~0.5.1",<% } %>
     "grunt-rev": "~0.1.0",
     "grunt-contrib-sass": "~0.5.0",
     "grunt-svgmin": "~0.2.0",


### PR DESCRIPTION
Usemin asset blocks would fail to load due to the fact that GitHub project pages live in subdomains. This PR fixes this issue by replacing asset load paths with the correct subdomain. Fixes #9.
