### PR TITLE
Update deployment methods and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ Run any test that you have defined for your source.
 Build the concatenated, minified production version of the source into the `dist` directory.
 
 ##### grunt deploy
-Deploy the production version of the source to [GitHub Pages](http://pages.github.com/) or [Heroku](https://www.heroku.com/) via [grunt-build-control](https://github.com/robwierzbowski/grunt-build-control). This ability is configurable during Playbook generation.
+Deploy the production version of the source to [GitHub Pages](http://pages.github.com/). This ability is configurable during Playbook generation.
 
 If you choose to utilize `grunt-build-control` to deploy a GitHub Pages user/organization site, your source must live in a branch other than `master`. GitHub Pages [user/organization sites](https://help.github.com/articles/user-organization-and-project-pages#project-pages) serve the files found in the `master` branch to the browser.

--- a/app/index.js
+++ b/app/index.js
@@ -112,7 +112,7 @@ PlaybookGenerator.prototype.askForDeployment = function askForDeployment() {
       name: 'deployHost',
       type: 'list',
       message: 'Host to deploy to',
-      choices: ['GitHub Pages', 'Heroku'],
+      choices: ['GitHub Pages', 'Generic remote'],
       when: function (answers) {
         return answers.deploy;
       }
@@ -132,13 +132,6 @@ PlaybookGenerator.prototype.askForDeployment = function askForDeployment() {
       }
     },
     {
-      name: 'herokuRepo',
-      message: 'Heroku app name',
-      when: function (answers) {
-        return answers.deployHost === 'Heroku';
-      }
-    },
-    {
       name: 'ghPagesProject',
       type: 'list',
       message: 'GitHub Project or User/Organization site?',
@@ -148,14 +141,23 @@ PlaybookGenerator.prototype.askForDeployment = function askForDeployment() {
       }
     },
     {
+      name: 'remoteURL',
+      message: 'Remote URL',
+      when: function (answers) {
+        return answers.deployHost === 'Generic remote';
+      }
+    },
+    {
       name: 'deployBranch',
       message: 'Branch to deploy to',
       default: function(answers) {
         if (answers.ghPagesProject === 'Project') {
           return 'gh-pages';
-        } else {
+        } else if (answers.ghPagesProject === 'User/Organization') {
           return 'master';
-        };
+        } else {
+          return 'dist';
+        }
       },
       when: function (answers) {
         return answers.deploy;
@@ -168,19 +170,19 @@ PlaybookGenerator.prototype.askForDeployment = function askForDeployment() {
   this.prompt(prompts, function (props) {
 
     this.deploy         = props.deploy;
-    this.deployBranch   = props.deployBranch;
+    this.deployHost     = props.deployHost;
     this.ghOwner        = props.ghOwner;
     this.ghRepo         = props.ghRepo;
-    this.deployHost     = props.deployHost;
+    this.deployBranch   = props.deployBranch;
 
     if (props.ghPagesProject) {
       this.ghPagesProject = props.ghPagesProject.replace('/', '_').toLowerCase();
     }
 
-    if (this.deployHost == 'Heroku') {
-      this.deployRemote = 'git@heroku.com:' + props.herokuRepo + '.git';
-    } else {
+    if (this.deployHost === 'GitHub Pages') {
       this.deployRemote = 'git@github.com:' + this.ghOwner + '/' + this.ghRepo + '.git';
+    } else {
+      this.deployRemote = props.remoteURL;
     }
 
     cb();

--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -26,4 +26,4 @@ Run any test that you have defined for your source.
 Build the concatenated, minified production version of the source into the `dist` directory.<% if (deploy) { %>
 
 ##### grunt deploy
-Deploy the production version of the source to <% if (deployHost === 'GitHub Pages') { %>[GitHub Pages](http://pages.github.com/)<% } %><% if (deployHost === 'Heroku') { %>[Heroku](https://www.heroku.com/)<% } %> via [grunt-build-control](https://github.com/robwierzbowski/grunt-build-control).<% } %>
+Deploy the production version of the source to <% if (deployHost === 'GitHub Pages') { %>[GitHub Pages](http://pages.github.com/)<% } %><% if (deployHost === 'Generic Git Remote') { %>the server<% } %> via [grunt-build-control](https://github.com/robwierzbowski/grunt-build-control).<% } %>


### PR DESCRIPTION
Removes references to Heroku deployment as it's not possible to deploy static sites to Heroku without some fancy work with [Rack](https://devcenter.heroku.com/articles/static-sites-ruby).
