### PR TITLE
prefix bitters install with bundle exec

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -241,7 +241,7 @@ PlaybookGenerator.prototype.jsPreprocessor = function jsPreprocessor() {
 PlaybookGenerator.prototype.installBitters = function installBitters() {
   // Install Bitters
   shelljs.cd('app/assets/_scss');
-  shelljs.exec('bitters install');
+  shelljs.exec('bundle exec bitters install');
   shelljs.cd('../../../');
 
   // Assimilate Bitters files


### PR DESCRIPTION
I ran into the issue described here: https://github.com/centresource/generator-playbook/issues/19

On my machine the 'bitters install' command failed during generation. I think the root cause is the fact that my bundler config uses a local BUNDLE_PATH.

``` shell
~ cat ~/.bundle/config

---
BUNDLE_PATH: .bundle
BUNDLE_BIN: .bundle/binstubs
BUNDLE_JOBS: '7'

~ echo $PATH
... :.bundle/binstubs: ...
```

So, if I try to run bitters in a subdirectory of my project (as the generator does), the executable is not found. Prefixing the command with bundle exec fixes this.

I am very new to yeoman so if there is a better way to fix, please let me know!
