### PR TITLE
Fixes import paths of mixins and extends for current Bitters

### DIFF
--- a/app/templates/app/assets/_scss/screen.scss
+++ b/app/templates/app/assets/_scss/screen.scss
@@ -18,8 +18,9 @@
 /* Base
  * -----------------------------------------------------------------------------*/
 @import "base/variables";
-@import "base/extends/base";
+@import "base/extends/extends";
 @import "base/mixins/base";
+@import "base/mixins/mixins";
 @import "base/utilities";
 @import "base/typography";
 @import "base/forms";


### PR DESCRIPTION
The package currently published on npm breaks because of wrong import paths. This seems to be due to ongoing structuring fixes that you will probably merge soon, but it would be great to fix this as a stopgap measure (or reference a specific Bitters version instead).
