### PR TITLE
Bump Jekyll version to 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Playbook is a Yeoman generator to get you building interfaces faster. [Jekyll](h
 [Grunt](http://gruntjs.com/) is used for compilation of [Sass](http://sass-lang.com) and [CoffeeScript](http://coffeescript.org) (optional). [Bower](http://bower.io/) is used for managing dependencies.
 
 ### Prerequisites
-If you do not have [Node.js](http://nodejs.org/) `>=0.10`, [Yeoman](http://yeoman.io/) `>=1.1.2`, [Ruby](https://www.ruby-lang.org/en/) `>=1.9` and the [Bundler](http://bundler.io/) gem installed, you must do that first:
+If you do not have [Node.js](http://nodejs.org/) `>=0.10`, [Yeoman](http://yeoman.io/) `>=1.1.2`, [Ruby](https://www.ruby-lang.org/en/) `>=2.0` and the [Bundler](http://bundler.io/) gem installed, you must do that first:
 
 - [Node.js](http://davidcalhoun.me/2013/12/16/developer-tools-homebrew/)
 - [Yeoman](http://yeoman.io/learning/index.html)

--- a/app/templates/Gemfile
+++ b/app/templates/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'jekyll', '~> 2.4'
+gem 'jekyll', '~> 2.5'
 gem 'redcarpet'
 gem 'csscss', '~> 1.3'<% if (sassComp === 'ruby') { %>
 gem 'sass', '~> 3.3.8'<% } %>


### PR DESCRIPTION
This could/should perhaps be split into two PRs as, like I said in #68 , Jekyll < 3.0 still supports Ruby 1.9.3.

So this bumps Jekyll up to the latest release and bumps up the listed Ruby requirement in the README.

I still haven't tested it yet, so consider it WIP.