### PR TITLE
Exit if current Ruby is < 2.x

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -14,10 +14,15 @@ var PlaybookGenerator = module.exports = function PlaybookGenerator(args, option
     return shelljs.which(depend);
   });
 
-  // Exit if Ruby dependencies aren't installed
-  if (!dependenciesInstalled) {
+  var isRubyTwoSpecified = function rubyTwoInstalled() {
+    var rubyVersion = shelljs.exec('ruby --version', { silent: true }).output;
+    return !/^ruby 2/.test(rubyVersion)
+  };
+
+  // Exit if Ruby < 2.x dependencies aren't installed
+  if (!dependenciesInstalled || !isRubyTwoSpecified) {
     console.log('Looks like you\'re missing some dependencies.' +
-      '\nMake sure ' + chalk.white('Ruby') + ' and the ' + chalk.white('Bundler gem') + ' are installed, then run again.');
+      '\nMake sure ' + chalk.white('Ruby (>= 2.0.0)') + ' and the ' + chalk.white('Bundler gem') + ' are installed, then run again.');
     shelljs.exit(1);
   }
 


### PR DESCRIPTION
related #71 and closing #68 .

This uses shelljs to get the current Ruby version and tests to make sure it starts with 2. If not it errors out using the dependencies check already in use.