### PR TITLE
Bump node-neat

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -25,7 +25,7 @@
     "gulp-size": "^1.2.0",
     "gulp-uglify": "^1.1.0",
     "gulp-useref": "^1.1.1",
-    "node-neat": "^1.4.2",
+    "node-neat": "^1.7.1-beta1",
     "run-sequence": "^1.0.2"
   }
 }


### PR DESCRIPTION
Bump node-neat to beta version that now wraps the [official bourbon-neat npm module](https://github.com/lacroixdesign/node-neat/commit/df978ca81fc47b4309b927c520e5337b1ac1cde2) which keeps Neat up to date with the latest official release.